### PR TITLE
Fix Cubejs server initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const CubejsServer = require('@cubejs-backend/server');
 
-const server = CubejsServer.create();
+const server = new CubejsServer();
 
 server.listen().then(({ version, port }) => {
   console.log(`🚀 Cube.js server (${version}) is running on port ${port}`);


### PR DESCRIPTION
## Summary
- instantiate CubejsServer with `new CubejsServer()` instead of calling `.create`

## Testing
- `node server.js` *(fails: cannot find module 'dotenv')*