### PR TITLE
Fix .env loading for Replit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Este proyecto inicia la construcción de un backend con [Cube.js](https://cube.d
    npm install
    ```
 2. Copia `.env.example` a `.env` y ajusta los valores de conexión a tu base de datos SQL Server.
+   Si no creas el archivo `.env`, el servidor intentará utilizar `.env.example` de forma automática.
+   Esto facilita pruebas en entornos como **Replit**, aunque se recomienda definir tus propias variables de entorno para producción.
 3. Inicia el servidor:
    ```bash
    npm start

--- a/server.js
+++ b/server.js
@@ -1,5 +1,29 @@
-require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load environment variables from .env if present. Fall back to .env.example so
+// the application can run out of the box (useful for environments like Replit).
+const envPath = path.resolve(process.cwd(), '.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  const exampleEnv = path.resolve(process.cwd(), '.env.example');
+  if (fs.existsSync(exampleEnv)) {
+    dotenv.config({ path: exampleEnv });
+    console.warn('Warning: .env file not found. Loaded variables from .env.example');
+  }
+}
+
 const CubejsServer = require('@cubejs-backend/server');
+
+if (!process.env.CUBEJS_DB_TYPE) {
+  console.error(
+    'Missing CUBEJS_DB_TYPE environment variable. ' +
+      'Check your .env configuration or create one based on .env.example.'
+  );
+  process.exit(1);
+}
 
 const server = new CubejsServer();
 


### PR DESCRIPTION
## Summary
- load `.env` or fallback to `.env.example` so environment variables are populated in Replit
- show a helpful error when `CUBEJS_DB_TYPE` is missing
- document automatic `.env.example` fallback in the README

## Testing
- `git status --short`